### PR TITLE
Counting in safari broke

### DIFF
--- a/js/wpadmin.js
+++ b/js/wpadmin.js
@@ -43,7 +43,7 @@ jQuery(function ($) {
 
         function doCount() {
             var chars = textarea.val().length;
-            var regex_matches = textarea.val().match(/[\^{}\\~€|\[\]]/gmu) || [];
+            var regex_matches = textarea.val().match(/[\^{}\\~€|\[\]]/gm) || [];
             chars += regex_matches.length;
             var split = chars <= 160 ? 160 : 153;
 


### PR DESCRIPTION
Seems that the unicode-flag broke Safari, but never mind - all browsers are unicode anyway, so it's a redundant flag (yes, I have tested that this holds true in the regex-comparison as well).

https://www.pivotaltracker.com/story/show/120281183
