### PR TITLE
V1.2.2 - Bugfix zeroes in numbers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.DS_Store

--- a/gatewayapi.php
+++ b/gatewayapi.php
@@ -3,7 +3,7 @@
 Plugin Name: GatewayAPI
 Plugin URI:  https://wordpress.org/plugins/gatewayapi/
 Description: Send SMS'es through WordPress.
-Version:     1.2.1
+Version:     1.2.2
 Author:      OnlineCity ApS
 Author URI:  http://onlinecity.dk
 License:     GPLv2

--- a/inc/cpt_sms.php
+++ b/inc/cpt_sms.php
@@ -92,7 +92,7 @@ function _gwapi_create_recipients_for_sms($ID, $tags)
         };
         foreach($tmp as $recID => $row) {
             if (!$row['cc'] || !$row['number']) continue;
-            $msisdn = $row['cc'].$row['number'];
+            $msisdn = $row['cc'].ltrim($row['number'],'0');
             $recipientsByNumber[$msisdn] = [];
             $recipientsByID[$recID] = $msisdn;
         }
@@ -127,7 +127,7 @@ function _gwapi_create_recipients_for_sms($ID, $tags)
 
     // manually added
     foreach(get_post_meta($ID, 'single_recipient') as $sr) {
-        $msisdn = $sr['cc'].$sr['number'];
+        $msisdn = $sr['cc'].ltrim($sr['number'],'0');
         if (isset($recipientsByNumber[$msisdn])) continue;
 
         $recipientsByNumber[$msisdn] = [];

--- a/inc/integration_contact_form_7.php
+++ b/inc/integration_contact_form_7.php
@@ -173,7 +173,7 @@ class GwapiContactForm7 {
 
 		// has the user entered a verification pin code?
 		if (!isset($_POST['_gwapi_verify_signup'])) {
-			$phone = preg_replace('/\D+/', '', $_POST['gwapi_country'].$_POST['gwapi_phone']);
+			$phone = preg_replace('/\D+/', '', $_POST['gwapi_country'].ltrim($_POST['gwapi_phone']. '0'));
 			$code = get_transient("gwapi_verify_signup_".$phone);
 
 			header("Content-type: application/json");
@@ -289,7 +289,7 @@ class GwapiContactForm7 {
 		$body = trim(wpcf7_mail_replace_tags($sms['reply-body']));
 		$from = trim(wpcf7_mail_replace_tags($sms['reply-sender'])) ? : null;
 
-		$phone = preg_replace('/\D+/', '', $_POST['gwapi_country'].$_POST['gwapi_phone']);
+		$phone = preg_replace('/\D+/', '', $_POST['gwapi_country'].ltrim($_POST['gwapi_phone'],'0'));
 		gwapi_send_sms($body, $phone, $from);
 	}
 
@@ -881,7 +881,7 @@ class GwapiContactForm7 {
 		// save + send verification SMS
 		$code = rand(100000,999999);
 		set_transient('gwapi_verify_'.$_POST['cc'].$_POST['number'], $code, 60*30);
-		gwapi_send_sms("Your verification code: ".$code, $_POST['cc'].$_POST['number']);
+		gwapi_send_sms(__("Your verification code:", 'gwapi').$code, $_POST['cc'].ltrim($_POST['number'], '0'));
 
 		die(json_encode(['success' => true]));
 	}

--- a/inc/shortcode.php
+++ b/inc/shortcode.php
@@ -118,8 +118,8 @@ function _gwapi_shortcode_handle_signup($atts)
         // STEP 2: CONFIRM SMS
         case 'signup_confirm_sms':
             // verify the information posted
-            $recipient = _gwapi_get_recipient($_POST['gwapi']['cc'], $_POST['gwapi']['number']);
-            $msisdn = preg_replace('/\D+/', '', $_POST['gwapi']['cc'].$_POST['gwapi']['number']);
+            $recipient = _gwapi_get_recipient($_POST['gwapi']['cc'], ltrim($_POST['gwapi']['number'], '0'));
+            $msisdn = preg_replace('/\D+/', '', $_POST['gwapi']['cc'].ltrim($_POST['gwapi']['number'], '0'));
             if (!is_wp_error($recipient)) return new WP_Error('already_exists',__('You are already subscribed with the phone number specified.','gwapi'));
 
             // save the information supplied by the user
@@ -201,7 +201,7 @@ function _gwapi_shortcode_handle_update($atts)
             if ($valid) {
                 // send the verification sms
                 $code = rand(100000,999999);
-                $msisdn = preg_replace('/\D+/', '', $_POST['gwapi']['cc'].$_POST['gwapi']['number']);
+                $msisdn = preg_replace('/\D+/', '', $_POST['gwapi']['cc'].ltrim($_POST['gwapi']['number'],'0'));
                 set_transient('gwapi_confirmation_code_'.$msisdn, $code, 60*60*4);
 
                 $status = gwapi_send_sms( strtr(__('Your confirmation code: %code%', 'gwapi'), ['%code%' => substr($code,0,3)." ".substr($code,3,3)]), $msisdn, '', 'DISPLAY' );

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link:
 Tags: sms, recipients, groups, mobile, phone
 Requires at least: 4.0
 Tested up to: 4.6.1
-Stable tag: 1.2.1
+Stable tag: 1.2.2
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 
@@ -116,6 +116,9 @@ Theoretically it works, but it's still in the early days for this plugin and thi
 4. Contact Form 7: Creating a "recipient groups" selection field.
 
 == Changelog ==
+
+= 1.2.2 =
+* Better international phone numbers support: Prefixed 0's in the phone number itself (between country prefix and phone number) is now correctly.
 
 = 1.2.1 =
 * User synchronization:


### PR DESCRIPTION
In some countries such as france and sweden, it is common to prefix a 0 to the phone number (area code), ie. between the country code and the local phone number.

This results in an invalid MSISDN. Prefixed zeroes to the phone number itself, has been removed.