### PR TITLE
Fully adjusted all parts depending on old name scheme

### DIFF
--- a/inc/integration_contact_form_7.php
+++ b/inc/integration_contact_form_7.php
@@ -51,6 +51,7 @@ class GwapiContactForm7 {
 		$this->resolveCF7SpamTrap();
 	}
 
+
 	/**
 	 * Make sure the CF7 spam trap is just being resolved once - especially reCaptcha fails if trying to verify the same
 	 * token twice, so after first succesful resolve, allow our own multi-use token.
@@ -192,9 +193,12 @@ class GwapiContactForm7 {
 		// must have phone and country code
 		if (!$phone_field || !$country_code_field) return;
 
+		$cc = $_POST[$country_code_field->name];
+		$local = $_POST[$phone_field->name];
+
 		// has the user entered a verification pin code?
 		if (!isset($_POST['_gwapi_verify_signup'])) {
-			$phone = gwapi_get_msisdn($_POST['gwapi_country'],$_POST['gwapi_phone']);
+			$phone = gwapi_get_msisdn($cc,$local);
 			$code = get_transient("gwapi_verify_signup_".$phone);
 
 			header("Content-type: application/json");
@@ -259,17 +263,20 @@ class GwapiContactForm7 {
 
 			if (!$country_code_field || !$phone_field || !$actions_field ) return; // nothing to do
 
+            $cc = $_POST[$country_code_field->name];
+            $local = $_POST[$phone_field->name];
+
 			$data = $submission->get_posted_data();
 
 			$curID = null;
-			if (in_array($data['gwapi_action'], ['unsubscribe', 'update'])) {
-				$q = new WP_Query(["post_type" => "gwapi-recipient", "meta_query" => [ [ 'key' => 'cc', 'value' => $_POST['gwapi_country'] ], ['key' => 'number', 'value' => $_POST['gwapi_phone']] ]]);
+			if (in_array($data[$actions_field['name']], ['unsubscribe', 'update'])) {
+				$q = new WP_Query(["post_type" => "gwapi-recipient", "meta_query" => [ [ 'key' => 'cc', 'value' => $cc ], ['key' => 'number', 'value' => $local ] ]]);
 				$curID = $q->post->ID;
 				if (!$curID) return; // should never happen, validation would have caught this...
 			}
 
 			$insert_data = null;
-			if (in_array($data['gwapi_action'], ['update', 'signup'])) {
+			if (in_array($data[$actions_field['name']], ['update', 'signup'])) {
 				// title/name for recipient
 				$title = '';
 				$name_fields = ['name', 'full_name'];
@@ -280,15 +287,15 @@ class GwapiContactForm7 {
 					if (isset($_POST['first_name'])) $title = $_POST['first_name'];
 					if (isset($_POST['last_name'])) $title .= " ".$_POST['last_name'];
 				}
-				if (!$title) $title = '+'.$data['gwapi_country']." ".$data['gwapi_phone'];
+				if (!$title) $title = '+'.$cc.' '.$local;
 
 				// data
 				$insert_data = [
 					"post_type" => "gwapi-recipient",
 					"post_status" => "publish",
 					"meta_input" => [
-						"cc" => $data['gwapi_country'],
-						"number" => $data['gwapi_phone']
+						"cc" => $cc,
+						"number" => $local
 					],
 					"post_title" => $title
 				];
@@ -323,7 +330,6 @@ class GwapiContactForm7 {
 
 						$groupIDs = isset($data['gwapi_groups']) && $data['gwapi_groups'] ? $data['gwapi_groups'] : [];
 						foreach($groupIDs as &$gid) { $gid = (int)$gid; }
-						//print_r([$groupIDs, $append_groups]);die();
 						wp_set_object_terms($curID, array_merge($groupIDs, $append_groups), 'gwapi-recipient-groups');
 					}
 
@@ -370,6 +376,10 @@ class GwapiContactForm7 {
 				<table class="form-table">
 					<tbody>
 					<tr>
+						<th scope="row"><label for="<?php echo esc_attr( $args['content'] . '-name' ); ?>"><?php _e('Name attribute', 'gwapi'); ?></label></th>
+						<td><input required type="text" name="name" class="tg-name oneline" id="<?php echo esc_attr( $args['content'] . '-name' ); ?>"></td>
+					</tr>
+                    <tr>
 						<th scope="row"><label for="<?php echo esc_attr( $args['content'] . '-id' ); ?>"><?php _e('Id attribute', 'gwapi'); ?></label></th>
 						<td><input type="text" name="id" class="idvalue oneline option" id="<?php echo esc_attr( $args['content'] . '-id' ); ?>"></td>
 					</tr>
@@ -410,7 +420,10 @@ class GwapiContactForm7 {
 
 				<table class="form-table">
 					<tbody>
-
+                    <tr>
+                        <th scope="row"><label for="<?php echo esc_attr( $args['content'] . '-name' ); ?>"><?php _e('Name attribute', 'gwapi'); ?></label></th>
+                        <td><input required type="text" name="name" class="tg-name oneline" id="<?php echo esc_attr( $args['content'] . '-name' ); ?>"></td>
+                    </tr>
 					<tr>
 						<th scope="row"><label for="<?php echo esc_attr( $args['content'] . '-groups' ); ?>"><?php _e('Limit countries', 'gwapi'); ?></label></th>
 						<td>
@@ -479,7 +492,10 @@ class GwapiContactForm7 {
 
 				<table class="form-table">
 					<tbody>
-
+                    <tr>
+                        <th scope="row"><label for="<?php echo esc_attr( $args['content'] . '-name' ); ?>"><?php _e('Name attribute', 'gwapi'); ?></label></th>
+                        <td><input required type="text" name="name" class="tg-name oneline" id="<?php echo esc_attr( $args['content'] . '-name' ); ?>"></td>
+                    </tr>
 					<tr>
 						<th scope="row"><label for="<?php echo esc_attr( $args['content'] . '-groups' ); ?>"><?php _e('Pick groups', 'gwapi'); ?></label></th>
 						<td>
@@ -543,7 +559,10 @@ class GwapiContactForm7 {
 
 				<table class="form-table">
 					<tbody>
-
+                    <tr>
+                        <th scope="row"><label for="<?php echo esc_attr( $args['content'] . '-name' ); ?>"><?php _e('Name attribute', 'gwapi'); ?></label></th>
+                        <td><input required type="text" name="name" class="tg-name oneline" id="<?php echo esc_attr( $args['content'] . '-name' ); ?>"></td>
+                    </tr>
 					<tr>
 						<th scope="row"><label for="<?php echo esc_attr( $args['content'] . '-action' ); ?>"><?php _e('Triggered action', 'gwapi'); ?></label></th>
 						<td>
@@ -654,7 +673,7 @@ class GwapiContactForm7 {
 		$default = $this->getFieldDefaultValue($default_field,'gwapi_country');
 		?>
 		<span class="<?= implode($classes,' '); ?>">
-			<input type="tel" name="gwapi_phone" id="<?= $field_id ? 'id="'.$field_id.'"' : ''; ?>" onkeyup="this.value = this.value.replace(/\D+/,'')" onchange="this.value = this.value.replace(/\D+/,'')" value="<?= esc_attr($default); ?>">
+			<input type="tel" data-gwapi="phone" name="<?= $contact_form['name']; ?>" id="<?= $field_id ? 'id="'.$field_id.'"' : ''; ?>" onkeyup="this.value = this.value.replace(/\D+/,'')" onchange="this.value = this.value.replace(/\D+/,'')" value="<?= esc_attr($default); ?>">
 		</span>
 		<?php
 
@@ -695,13 +714,13 @@ class GwapiContactForm7 {
 		if (count($country_codes) === 1):
 			?>
 			<span class="<?= implode($classes,' '); ?>">
-				<input type="hidden" name="gwapi_country" value="<?= current($country_codes); ?>" <?= $field_id ? 'id="'.$field_id.'"' : ''; ?>>
+				<input type="hidden"  data-gwapi="country" name="<?= $contact_form['name']; ?>" value="<?= current($country_codes); ?>" <?= $field_id ? 'id="'.$field_id.'"' : ''; ?>>
 			</span>
 			<?php
 		else:
 			?>
 				<span class="<?= implode($classes,' '); ?>">
-					<select name="gwapi_country" <?= $field_id ? 'id="'.$field_id.'"' : ''; ?> <?= ($default?'value="'.esc_attr($default).'"':''); ?>>
+					<select  data-gwapi="country" name="<?= $contact_form['name']; ?>" <?= $field_id ? 'id="'.$field_id.'"' : ''; ?> <?= ($default?'value="'.esc_attr($default).'"':''); ?>>
 						<?php foreach($out_country_codes as $c): ?>
 							<option value="<?= $c->phone; ?>" <?= $default==$c->phone?'selected':'' ?>><?= $c->name ?> (+<?= $c->phone; ?>)</option>
 						<?php endforeach; ?>
@@ -737,14 +756,14 @@ class GwapiContactForm7 {
 			?>
 			<div class="<?= implode($classes,' '); ?>">
 				<?php foreach($groups as $g): ?>
-					<label style="margin-bottom: 5px; display: block;"><input type="checkbox" name="gwapi_groups[]" value="<?= $g->term_id; ?>"> <?= esc_html($g->name); ?></label>
+					<label style="margin-bottom: 5px; display: block;"><input type="checkbox"  data-gwapi="groups" name="<?= $contact_form['name']; ?>[]" value="<?= $g->term_id; ?>"> <?= esc_html($g->name); ?></label>
 				<?php endforeach; ?>
 			</div>
 		<?php
 		else:
 			foreach($groups as $g): ?>
 			<span class="<?= implode($classes,' '); ?>">
-				<input type="hidden" name="gwapi_groups[]" value="<?= $g->term_id; ?>">
+				<input type="hidden"  data-gwapi="groups" name="<?= $contact_form['name']; ?>[]" value="<?= $g->term_id; ?>">
 			</span>
 			<?php endforeach;
 		endif;
@@ -763,13 +782,10 @@ class GwapiContactForm7 {
 	 */
 	public function validateGroups(WPCF7_Validation $res, $tag)
 	{
-		$tag['name'] = 'gwapi-groups';
 		$tag = new WPCF7_Shortcode( $tag );
-
 		$groupsPossible = $this->getGroupIdsFromTag($tag);
-
 		$groupsPossible = array_unique($groupsPossible);
-		$groupsSelected = isset($_POST['gwapi_groups']) ? array_unique($_POST['gwapi_groups']) : [];
+		$groupsSelected = isset($_POST[$tag->name]) ? array_unique($_POST[$tag->name]) : [];
 
 		// if NOT hidden, then check:
 		// are the groups selected within the list of possible groups?
@@ -799,31 +815,36 @@ class GwapiContactForm7 {
 	 */
 	public function validatePhone(WPCF7_Validation $res, $tag)
 	{
-		$tag['name'] = 'gwapi-phone';
+	    $cf = WPCF7_ContactForm::get_current(); /** @var $cf WPCF7_ContactForm */
+	    $action_field = current($cf->scan_form_tags(['type' => 'gw_action']));
+	    $cc_field = current($cf->scan_form_tags(['type' => 'gw_country']));
+	    $local_field = current($cf->scan_form_tags(['type' => 'gw_phone']));
+
 		$tag = new WPCF7_Shortcode( $tag );
 
-		$phone = isset($_POST['gwapi_phone']) ? $_POST['gwapi_phone'] : null;
+		$phone = isset($_POST[$local_field['name']]) ? $_POST[$local_field['name']] : null;
 		if (!$phone || !ctype_digit($phone)) {
 			$res->invalidate($tag, __('The phone number must consist of digits only.', 'gwapi') );
 			return $res;
 		}
 
-		$action = isset($_POST['gwapi_action']) ? $_POST['gwapi_action'] : null;
+		$action = isset($_POST[$action_field['name']]) ? $_POST[$action_field['name']] : null;
 		if (!$action) return $res; // invalid, but this post will simply be ignored because of that, which is good
 
 		$phone_exists = null;
-		if (isset($_POST['gwapi_country']) && $_POST['gwapi_country'] && isset($_POST['gwapi_phone']) && $_POST['gwapi_phone']) {
-			$q = new WP_Query(["post_type" => "gwapi-recipient", "meta_query" => [ [ 'key' => 'cc', 'value' => $_POST['gwapi_country'] ], ['key' => 'number', 'value' => $_POST['gwapi_phone']] ]]);
+		$cc = isset($_POST[$cc_field['name']]) ? $_POST[$cc_field['name']] : null;
+		if ($cc) {
+			$q = new WP_Query(["post_type" => "gwapi-recipient", "meta_query" => [ [ 'key' => 'cc', 'value' => $cc ], ['key' => 'number', 'value' => $phone] ]]);
 			$phone_exists = $q->have_posts();
 		}
 
 		// signup: does the phone number already exist?
-		if (isset($_POST['gwapi_action']) && $_POST['gwapi_action'] == 'signup' && $phone_exists === true) {
+		if ($action && $action == 'signup' && $phone_exists === true) {
 			$res->invalidate($tag, __('You are already subscribed with this phone number.', 'gwapi') );
 		}
 
 		// unsubscribe or update: does the phone number already exist?
-		if (isset($_POST['gwapi_action']) && in_array($_POST['gwapi_action'], ['unsubscribe', 'update']) && $phone_exists === false) {
+		if ($action && in_array($action, ['unsubscribe', 'update']) && $phone_exists === false) {
 			$res->invalidate($tag, __('You are not subscribed with this phone number.', 'gwapi') );
 		}
 
@@ -840,10 +861,12 @@ class GwapiContactForm7 {
 	 */
 	public function validateCountry(WPCF7_Validation $res, $tag)
 	{
-		$tag['name'] = 'gwapi-country';
+        $cf = WPCF7_ContactForm::get_current(); /** @var $cf WPCF7_ContactForm */
+        $cc_field = current($cf->scan_form_tags(['type' => 'gw_country']));
+
 		$tag = new WPCF7_Shortcode( $tag );
 
-		$cc = isset($_POST['gwapi_country']) ? $_POST['gwapi_country'] : null;
+		$cc = isset($_POST[$cc_field['name']]) ? $_POST[$cc_field['name']] : null;
 
 		// do we have a list of country codes to limit from?
 		$valid_country_codes = [];
@@ -878,22 +901,22 @@ class GwapiContactForm7 {
 	 */
 	public function validateAction(WPCF7_Validation $res, $tag)
 	{
-		$origName = $tag['name'];
-		$tag['name'] = 'gwapi-action';
+        $cf = WPCF7_ContactForm::get_current(); /** @var $cf WPCF7_ContactForm */
+        $action_field = current($cf->scan_form_tags(['type' => 'gw_action']));
+        $cc_field = current($cf->scan_form_tags(['type' => 'gw_country']));
+        $local_field = current($cf->scan_form_tags(['type' => 'gw_phone']));
+
+        $phone = isset($_POST[$local_field['name']]) ? $_POST[$local_field['name']] : null;
+        $cc = isset($_POST[$cc_field['name']]) ? $_POST[$cc_field['name']] : null;
+
 		$tag = new WPCF7_Shortcode( $tag );
 
 		// the action selected must be within the list of valid actions
-		$action = isset($_POST['gwapi_action']) ? $_POST['gwapi_action'] : '';
-		$shouldBe = substr($origName, 7);
-
-		if ($shouldBe != $action) {
-			$res->invalidate($tag, __('The action for the form is not consistent with the per-form configured action. This should not happen, but may occur if the editor of this site has changed the settings for this form since you opened this page.', 'gwapi') );
-			return $res;
-		}
+		$action = isset($_POST[$action_field['name']]) ? $_POST[$action_field['name']] : '';
 
 		// update action + verification
 		if ($action === 'update' && in_array('verify:yes', $tag->options)) {
-			$code = get_transient('gwapi_verify_'.$_POST['gwapi_country'].$_POST['gwapi_phone']);
+			$code = get_transient('gwapi_verify_'.gwapi_get_msisdn($cc, $phone));
 			if ($code != $_POST['_gwapi_token']) {
 				$res->invalidate($tag, __('It doesn\'t seem that you have verified your number by SMS, or the verification has expired. Note that you must submit the form within 30 minutes after validating.', 'gwapi') );
 			}
@@ -901,8 +924,8 @@ class GwapiContactForm7 {
 
 		// signup action + verification
 		if ($action === 'signup' && in_array('verify:yes', $tag->options)) {
-			$phone = preg_replace('/\D+/', '', $_POST['gwapi_country'].$_POST['gwapi_phone']);
-			$code = get_transient("gwapi_verify_signup_" . $phone);
+			$msisdn = gwapi_get_msisdn($cc, $phone);
+			$code = get_transient("gwapi_verify_signup_" . $msisdn);
 			if (isset($_POST['_gwapi_verify_signup'])) {
 				if ($code && $code != preg_replace('/\D+/', '', $_POST['_gwapi_verify_signup'])) {
 					$res->invalidate($tag, __("The verification code that you entered, was incorrect.", 'gwapi') );
@@ -922,7 +945,7 @@ class GwapiContactForm7 {
 		ob_start();
 		?>
 		<span class="<?= implode($classes,' '); ?>">
-			<input type="hidden" <?= $with_verify ? 'data-verify="true"' : ''; ?> name="gwapi_action" value="<?= substr($contact_form['name'], strpos($contact_form['name'], ':')+1); ?>">
+			<input type="hidden" <?= $with_verify ? 'data-verify="true"' : ''; ?>  data-gwapi="action" name="<?= $contact_form['name']; ?>" value="<?= substr($contact_form['name'], strpos($contact_form['name'], ':')+1); ?>">
 		</span>
 
 		<?php
@@ -1017,7 +1040,7 @@ class GwapiContactForm7 {
 		if ($first_call) return;
 		$first_call = true;
 
-		wp_enqueue_script('gwapi_integration_contact_form_7', _gwapi_url().'js/integration_contact_form_7.js', ['jquery']);
+		wp_enqueue_script('gwapi_integration_contact_form_7', _gwapi_url().'js/integration_contact_form_7.js', ['jquery'], 2);
 		wp_localize_script('gwapi_integration_contact_form_7', 'i18n_gwapi_cf7', [
 			'country_and_cc' => __('You must supply both country code and phone number in order to continue.', 'gwapi'),
 			'verification_sms_sent' => __("We have just sent you an SMS with a verification code. Please enter it below:", 'gwapi'),

--- a/js/integration_contact_form_7.js
+++ b/js/integration_contact_form_7.js
@@ -44,7 +44,7 @@ jQuery(function($) {
         $('.wpcf7-form-control-wrap').each(function() {
             var fields = $(this).find('input,select');
             fields.each(function() {
-                if ($(this).attr('name') == 'gwapi_country' || $(this).attr('name') == 'gwapi_phone') return;
+                if ($(this).attr('data-gwapi') == 'country' || $(this).attr('data-gwapi') == 'phone') return;
 
                 var prevParent = null;
                 var hideMeParent = null;
@@ -121,7 +121,13 @@ jQuery(function($) {
 
                     // for the rest of the fields, update with the current value
                     $.each(res.recipient, function(key, val) {
-                        var el = $('.wpcf7-form [name="'+key+'"], .wpcf7-form [name="'+key+'[]"]');
+                        var el = '';
+                        if (key.substr(0,5) == 'gwapi') {
+                            el = $('.wpcf7-form [data-gwapi="'+key.substr(6)+'"]');
+                        } else {
+                            el = $('.wpcf7-form [name="'+key+'"], .wpcf7-form [name="'+key+'[]"]');
+                        }
+
                         if (Array.isArray(val)) {
                             el.prop('checked', false);
                             $.each(val, function(key2, val2) {

--- a/js/integration_contact_form_7.js
+++ b/js/integration_contact_form_7.js
@@ -5,7 +5,7 @@ jQuery(function($) {
     {
 
         // find the action-tag
-        actionEl = $('.wpcf7-form input[name="gwapi_action"]');
+        actionEl = $('.wpcf7-form input[data-gwapi="action"]');
 
         // requires verify?
         if (actionEl.data('verify')) {
@@ -73,8 +73,8 @@ jQuery(function($) {
 
         // on success, update the form, hide own submit and insert real submit
         newSubmit.click(function() {
-            var cc = $('[name="gwapi_country"]').val();
-            var mobile = $('[name="gwapi_phone"]').val();
+            var cc = $('[data-gwapi="country"]').val();
+            var mobile = $('[data-gwapi="phone"]').val();
             if (!cc || !mobile) {
                 $('.wpcf7-response-output').text(i18n_gwapi_cf7.country_and_cc).addClass('wpcf7-validation-errors').show();
                 return false;
@@ -107,9 +107,9 @@ jQuery(function($) {
                     $('<input type="hidden" name="_gwapi_token" value="'+code+'">').insertAfter(actionEl);
 
                     // mark the phone and country code fields readonly
-                    $('[name="gwapi_phone"]').prop('readonly', true);
-                    var gwapiCountryEl = $('[name="gwapi_country"]').prop('disabled', true);
-                    $('<input type="hidden" name="gwapi_country">').val(cc).insertAfter(gwapiCountryEl);
+                    $('[data-gwapi="phone"]').prop('readonly', true);
+                    var gwapiCountryEl = $('[data-gwapi="country"]').prop('disabled', true);
+                    $('<input type="hidden" name="'+gwapiCountryEl.attr('name')+'">').val(cc).insertAfter(gwapiCountryEl);
 
                     // remove our submit and re-insert all hidden fields and re-enable proper submit
                     newSubmit.remove();


### PR DESCRIPTION
Previously the CF7-forms always posted using the same form keys, but this broke in regards to CF7's tag processing. All parts depending on this approach (a lot!) has been rewritten to use the CF7-style name tags.