### PR TITLE
Better support for SMSes with lots of recipients

### DIFF
--- a/css/wpadmin.css
+++ b/css/wpadmin.css
@@ -328,3 +328,32 @@ i.info {
 .gwapi-about-help a {
     color: white;
 }
+
+/* sms-status sending */
+#sms-status .progress {
+    height: 20px;
+    border: 1px solid #e5e5e5;
+    border-radius: 3px 3px;
+    background-color: #e5e5e5;
+}
+
+#sms-status .progress .completed {
+    height: 20px;
+    background-color: blue;
+}
+
+#sms-status .text-ellipsis {
+    width: 100%;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    overflow: hidden;
+    box-sizing: border-box;
+    border: 1px solid #efefef;
+    padding: 5px;
+}
+
+#sms-status .text-ellipsis:hover {
+    white-space: normal;
+    overflow: auto;
+    max-height: 150px;
+}

--- a/gatewayapi.php
+++ b/gatewayapi.php
@@ -3,7 +3,7 @@
 Plugin Name: GatewayAPI
 Plugin URI:  https://wordpress.org/plugins/gatewayapi/
 Description: Send SMS'es through WordPress.
-Version:     1.4.1
+Version:     1.4.2
 Author:      OnlineCity ApS
 Author URI:  http://onlinecity.dk
 License:     GPLv2

--- a/inc/api.php
+++ b/inc/api.php
@@ -72,7 +72,7 @@ function gwapi_send_sms($message, $recipients, $sender='', $destaddr='MOBILE')
     // ============
 
     // possible URIs
-    $uris = ['https://gatewayapi.live/rest/mtsms', 'https://badssl.gatewayapi.live/rest/mtsms', 'http://badssl.gatewayapi.live/rest/mtsms'];
+    $uris = ['https://gatewayapi.com/rest/mtsms', 'https://badssl.gatewayapi.com/rest/mtsms', 'http://badssl.gatewayapi.com/rest/mtsms'];
 
     $ts = time()-3;
     foreach($uris as $i=>$uri) {

--- a/inc/api.php
+++ b/inc/api.php
@@ -72,7 +72,7 @@ function gwapi_send_sms($message, $recipients, $sender='', $destaddr='MOBILE')
     // ============
 
     // possible URIs
-    $uris = ['https://gatewayapi.com/rest/mtsms', 'https://badssl.gatewayapi.com/rest/mtsms', 'http://badssl.gatewayapi.com/rest/mtsms'];
+    $uris = ['https://gatewayapi.live/rest/mtsms', 'https://badssl.gatewayapi.live/rest/mtsms', 'http://badssl.gatewayapi.live/rest/mtsms'];
 
     $ts = time()-3;
     foreach($uris as $i=>$uri) {

--- a/inc/cpt_sms.php
+++ b/inc/cpt_sms.php
@@ -45,7 +45,7 @@ add_action('publish_gwapi-sms', function($ID) {
 
     // send the SMS now
     update_post_meta($ID, 'api_status', 'about_to_send');
-    do_action('gwapi_send_sms', $ID);
+    do_action('gwapi_prepare_sms', $ID);
 });
 
 /**
@@ -153,11 +153,11 @@ function _gwapi_create_recipients_for_sms($ID, $tags)
 }
 
 /**
- * Do the actual sending.
+ * Prepare the SMS to be sent.
  *
  * @internal This hook is NOT protected against multiple calls and should NOT be called directly.
  */
-add_action('gwapi_send_sms', function($ID) {
+add_action('gwapi_prepare_sms', function($ID) {
     if (wp_is_post_revision($ID)) return; // no reason to spend any more time on a revision
     if (get_post_meta($ID, 'api_status', true) != 'about_to_send') return; // got here some wrong way
     update_post_meta($ID, 'api_status', 'sending');
@@ -195,16 +195,6 @@ add_action('gwapi_send_sms', function($ID) {
         update_post_meta($ID, 'api_status', 'bail');
         update_post_meta($ID, 'api_error', 'No recipients added.');
         return;
-    }
-    $send_req = gwapi_send_sms($message, $recipients, $sender, $destaddr);
-
-    if (!is_wp_error($send_req)) {
-        update_post_meta($ID, 'api_status', 'is_sent');
-        update_post_meta($ID, 'api_ids', $send_req);
-    } else {
-        /** @var $send_req WP_Error */
-        update_post_meta($ID, 'api_status', 'tech_error');
-        update_post_meta($ID, 'api_error', json_encode($send_req->get_error_message()));
     }
 });
 

--- a/inc/cpt_sms_editor_ui.php
+++ b/inc/cpt_sms_editor_ui.php
@@ -2,6 +2,8 @@
 /**
  * SMS Editor
  */
+const _GWAPIUI_MAX_RECIPIENTS_PER_BATCH = 500;
+
 add_action('admin_init', function () {
     add_meta_box('sms-recipients', __('Recipients', 'gwapi'), '_gwapi_sms_recipients', 'gwapi-sms', 'normal', 'default');
     add_meta_box('sms-recipient-groups', __('Recipient groups', 'gwapi'), '_gwapi_sms_recipient_groups', 'gwapi-sms', 'normal', 'default');
@@ -255,7 +257,9 @@ function _gwapi_sms_status(WP_Post $post) {
             break;
 
         case 'sending':
-            echo __('Sending...', 'gwapi');
+            $is_sending = $post->batch_is_running;
+
+            echo '<strong style="color: blue" '.(!$is_sending ? 'data-should-send' : '').'>'.__('Sending...', 'gwapi').'</strong>';
             break;
 
         case 'bail':
@@ -271,7 +275,7 @@ function _gwapi_sms_status(WP_Post $post) {
             break;
 
         case 'is_sent':
-            echo '<span style="color: green; font-weight: bold">'.__('SMS was successfully sent', 'gwapi').'</span><br />ID: '.$ids;
+            echo '<span style="color: green; font-weight: bold">'.__('SMS was successfully sent', 'gwapi').'</span><br /><div class="text-ellipsis">ID: '.implode(', ',$ids).'</div>';
             break;
 
         default:
@@ -280,7 +284,19 @@ function _gwapi_sms_status(WP_Post $post) {
     }
     ?>
     </p>
+    <?php
 
+    if ($status == 'sending') _gwapi_get_sent_status_progress($post);
+}
+
+function _gwapi_get_sent_status_progress(WP_Post $post)
+{
+    $recipients_total = (int)get_post_meta($post->ID, 'recipients_count', true);
+    $recipients_handled = (int)(get_post_meta($post->ID, 'recipients_handled', true) ? : 0);
+    ?>
+    <div class="progress">
+        <div class="completed" style="width: <?= $recipients_handled / $recipients_total * 100; ?>%"></div>
+    </div>
     <?php
 }
 
@@ -410,4 +426,67 @@ add_action('wp_ajax_gatewayapi_sms_manual_delete_recipient', function () {
     $wpdb->query($q = $wpdb->prepare("DELETE FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_id = %d AND meta_key = 'single_recipient';", $post_ID, $_POST['meta_ID']));
 
     die(json_encode(['success' => true, $q]));
+});
+
+/**
+ * AJAX: Send next batch of SMS.
+ */
+add_action('wp_ajax_gwapi_send_next_batch', function() {
+    header("Content-type: application/json");
+
+    $post = get_post($_POST['post_ID']);
+    $ID = $post->ID;
+
+    try {
+        if (get_post_type($post) != 'gwapi-sms') throw new InvalidArgumentException(__('Invalid post type.', 'gwapi'));
+        $status = get_post_meta($post->ID, 'api_status', true);
+        if ($status != 'sending') throw new \InvalidArgumentException(__('SMS is not in the right state for sending.','gwapi'));
+        if ($post->batch_is_running) throw new \InvalidArgumentException(__('Sending is already in progress','gwapi'));
+
+        update_post_meta($ID, 'batch_is_running', time());
+
+        // who is in next batch?
+        $handled_count = (int)$post->recipients_handled ? : 0;
+
+        // ensure we don't try to send the same batch multiple times
+        update_post_meta($ID, 'recipients_handled', $handled_count + _GWAPIUI_MAX_RECIPIENTS_PER_BATCH);
+
+        // base information for SMS
+        $sender = $post->sender;
+        $message = $post->message;
+        $destaddr = $post->destaddr ? : 'MOBILE';
+
+        // get all recipients
+        $allTags = _gwapi_extract_tags_from_message($message);
+        $allRecipients = _gwapi_create_recipients_for_sms($ID, $allTags);
+        $recipients = array_slice($allRecipients, $handled_count, _GWAPIUI_MAX_RECIPIENTS_PER_BATCH, true);
+
+        $send_req = gwapi_send_sms($message, $recipients, $sender, $destaddr);
+
+        if (!is_wp_error($send_req)) {
+            if ($handled_count + _GWAPIUI_MAX_RECIPIENTS_PER_BATCH >= count($allRecipients)) {
+                update_post_meta($ID, 'api_status', 'is_sent');
+            }
+
+            $ids = $post->api_ids ? : [];
+            $ids[] = $send_req;
+            update_post_meta($ID, 'api_ids', $ids);
+        } else {
+            /** @var $send_req WP_Error */
+            update_post_meta($ID, 'api_status', 'tech_error');
+            update_post_meta($ID, 'api_error', json_encode($send_req->get_error_message()));
+        }
+
+        // reset the "batch_is_running" status
+        update_post_meta($post->ID, 'batch_is_running', false);
+
+    } catch(\Exception $e) {
+        die(json_encode(['error' => $e->getMessage()]));
+    }
+
+    ob_start();
+    _gwapi_sms_status(get_post($ID));
+
+    $html = ob_get_clean();
+    die(json_encode(['status' => 'success', 'html' => $html]));
 });

--- a/js/wpadmin.js
+++ b/js/wpadmin.js
@@ -23,6 +23,8 @@ jQuery(function ($) {
             handleAddSingleRecipient();
             handleRemoveSingleRecipient();
             lockdownOnPublish();
+
+            handleSending();
         }
 
         if (has_recipient_ui) {
@@ -379,6 +381,22 @@ jQuery(function ($) {
               form.submit();
            });
         }
+    }
+
+    /**
+     * When status is "sending", start the batch-sender.
+     */
+    function handleSending()
+    {
+        if (!$('#sms-status [data-should-send]').length) return;
+
+        $.post(ajaxurl, {
+            'action': 'gwapi_send_next_batch',
+            'post_ID': $('#post_ID').val()
+        }).done(function(ret) {
+            $('#sms-status .inside').html(ret.html);
+            handleSending();
+        });
     }
 
     initialize();

--- a/js/wpadmin.js
+++ b/js/wpadmin.js
@@ -388,15 +388,14 @@ jQuery(function ($) {
      */
     function handleSending()
     {
-        if (!$('#sms-status [data-should-send]').length) return;
+        if (!$('#sms-status [data-is-sending]').length) return;
 
-        $.post(ajaxurl, {
-            'action': 'gwapi_send_next_batch',
-            'post_ID': $('#post_ID').val()
-        }).done(function(ret) {
-            $('#sms-status .inside').html(ret.html);
-            handleSending();
-        });
+        setTimeout(function() {
+            $.get(ajaxurl+'?action=gwapi_get_html_status&ID='+$('#post_ID').val(), function(ret) {
+                $('#sms-status .inside').html(ret);
+                handleSending();
+            })
+        }, 5000);
     }
 
     initialize();

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Donate link:
 Tags: sms, recipients, groups, mobile, phone
 Requires at least: 4.0
 Tested up to: 4.7.2
-Stable tag: 1.4.1
+Stable tag: 1.4.2
 License: MIT
 License URI: https://opensource.org/licenses/MIT
 
@@ -128,6 +128,9 @@ Theoretically it works, but it's still in the early days for this plugin and thi
 4. Contact Form 7: Creating a "recipient groups" selection field.
 
 == Changelog ==
+
+= 1.4.2 =
+* Fix: Improved handling of huge lists of recipients (ie. 1.000+ recipients in one SMS)
 
 = 1.4.1 =
 * Fix: List of countries is now always correctly parsed, even when the JSON-file (which is fetched via AJAX) does not have right mime-type.

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: onlinecity
 Donate link:
 Tags: sms, recipients, groups, mobile, phone
 Requires at least: 4.0
-Tested up to: 4.7.2
+Tested up to: 4.9.6
 Stable tag: 1.4.2
 License: MIT
 License URI: https://opensource.org/licenses/MIT


### PR DESCRIPTION
In order to support sending SMS'es to a large amount of recipients, our UI now sends SMS'es in 500-recipient increments, instead of just one big request. Hopefully this alleviates the HTTP-issues some clients have experienced.

Has progress bar in the backend. Also supports scheduled SMS'es.