### PR TITLE
added autcomplete for one-time-code for iOS devices

### DIFF
--- a/tpl/wp-login-confirm-phone.php
+++ b/tpl/wp-login-confirm-phone.php
@@ -13,7 +13,7 @@
 
     <p>
         <label for="gwapi_confirm_code"><?php _e('Confirmation code', 'gatewayapi'); ?><br>
-            <input type="number" name="code" id="gwapi_confirm_code" class="input" value="" size="20">
+            <input type="number" name="code" id="gwapi_confirm_code" class="input" value="" size="20" autocomplete="one-time-code">
         </label>
     </p>
 


### PR DESCRIPTION
This pull request will ensure one-time-codes for iOS devices are auto-filled: https://developer.apple.com/documentation/security/password_autofill/enabling_password_autofill_on_an_html_input_element