### PR TITLE
Fix: Ensure redirect_to Parameter is Respected After Two-Factor Authentication

### DIFF
--- a/inc/security_two_factor.php
+++ b/inc/security_two_factor.php
@@ -52,7 +52,8 @@ class GwapiSecurityTwoFactor
 
     if (!self::userNeedsTwoFactor($user)) return;
     if (self::userHasValidTwofactorCookie($user)) return;
-    self::replaceLoginCookieWithTempCookie($user);
+    $redirect_to = $_POST['redirect_to'] ?? null; // Capture the redirect_to parameter
+    self::replaceLoginCookieWithTempCookie($user, $redirect_to); // Pass it to the method
     self::renderTwoFactorSteps($user);
 
     die();


### PR DESCRIPTION
This pull request addresses a bug where the `redirect_to` parameter was not being respected after a user successfully logs in with two-factor authentication. The changes ensure that the user is redirected to the intended URL after completing the two-factor authentication process.